### PR TITLE
Fix file and file descriptor leaks

### DIFF
--- a/command.c
+++ b/command.c
@@ -352,7 +352,9 @@ void showpos()
 char* get_temp_file()
 {
 	static char temp_file[] = TEMPFILE;
+	int fd;
 	strcpy(temp_file, TEMPFILE);
-	if (-1 == mkstemp(temp_file)) fatal("%s: Failed to create temp file\n");
+	if (-1 == (fd = mkstemp(temp_file))) fatal("%s: Failed to create temp file\n");
+	close(fd);
 	return temp_file;
 }

--- a/complete.c
+++ b/complete.c
@@ -9,7 +9,7 @@ int getfilename(char *prompt, char *buf, int nbuf)
 	int c, ocpos, n, nskip = 0, didtry = 0, iswild = 0, result = 0;
 
 	char sys_command[255];
-	char *output_file = get_temp_file();
+	char *output_file = NULL;
 	FILE *fp = NULL;
 	buf[0] ='\0';
 
@@ -24,9 +24,13 @@ int getfilename(char *prompt, char *buf, int nbuf)
 		case 0x0a: /* cr, lf */
 		case 0x0d:
 			buf[cpos] = 0;
+			if (fp != NULL)
+				fclose(fp);
 			return (cpos > 0 ? TRUE : FALSE);
 
 		case 0x07: /* ctrl-g, abort */
+			if (fp != NULL)
+				fclose(fp);
 			return FALSE;
 
 		case 0x7f: /* del, erase */


### PR DESCRIPTION
This PR fixes the errors reported in #7.

get_temp_file() calls mkstemp which returns both a filename and an
open file descriptor, but the latter was discarded. (+2 lines)

getfilename() called get_temp_file() once on entry without using the
result.

Return from getfilename() left a file open if completion was ever
attempted. (+4 lines).