### PR TITLE
Rework filename completion

### DIFF
--- a/command.c
+++ b/command.c
@@ -348,13 +348,3 @@ void showpos()
 			curbp->b_point, ((curbp->b_ebuf - curbp->b_buf) - (curbp->b_egap - curbp->b_gap)));
 	}
 }
-
-char* get_temp_file()
-{
-	static char temp_file[] = TEMPFILE;
-	int fd;
-	strcpy(temp_file, TEMPFILE);
-	if (-1 == (fd = mkstemp(temp_file))) fatal("%s: Failed to create temp file\n");
-	close(fd);
-	return temp_file;
-}

--- a/command.c
+++ b/command.c
@@ -352,7 +352,9 @@ void showpos()
 char* get_temp_file()
 {
 	static char temp_file[] = TEMPFILE;
+	int fd;
 	strcpy(temp_file, TEMPFILE);
-	if (-1 == mkstemp(temp_file)) fatal("%s: Failed to create temp file\n");
+	if (-1 == (fd = mkstemp(temp_file))) fatal("%s: Failed to create temp file\n");
+	close(fd);
 	return temp_file;
 }

--- a/complete.c
+++ b/complete.c
@@ -50,12 +50,11 @@ int getfilename(char *prompt, char *buf, int nbuf)
 
 			/* scan backwards for a wild card and set */
 			iswild=0;
-			while (cpos > -1) {
+			while (cpos > 0) {
+				cpos--;
 				if (buf[cpos] == '*' || buf[cpos] == '?')
 					iswild = 1;
-				cpos--;
 			}
-			cpos=0;
 
 			/* first time retrieval */
 			if (nskip < 0) {

--- a/complete.c
+++ b/complete.c
@@ -9,7 +9,7 @@ int getfilename(char *prompt, char *buf, int nbuf)
 	int c, ocpos, n, nskip = 0, didtry = 0, iswild = 0, result = 0;
 
 	char sys_command[255];
-	char *output_file = get_temp_file();
+	char *output_file = NULL;
 	FILE *fp = NULL;
 	buf[0] ='\0';
 
@@ -24,9 +24,13 @@ int getfilename(char *prompt, char *buf, int nbuf)
 		case 0x0a: /* cr, lf */
 		case 0x0d:
 			buf[cpos] = 0;
+			if (fp != NULL)
+				fclose(fp);
 			return (cpos > 0 ? TRUE : FALSE);
 
 		case 0x07: /* ctrl-g, abort */
+			if (fp != NULL)
+				fclose(fp);
 			return FALSE;
 
 		case 0x7f: /* del, erase */

--- a/complete.c
+++ b/complete.c
@@ -7,7 +7,7 @@ int getfilename(char *prompt, char *buf, int nbuf)
 {
 	static char temp_file[] = TEMPFILE;
 	int cpos = 0;	/* current character position in string */
-	int c, n, fd, nskip = 0, didtry = 0, iswild = 0;
+	int c, fd, nskip = 0, didtry = 0, iswild = 0;
 
 	char sys_command[255];
 	FILE *fp = NULL;
@@ -46,8 +46,6 @@ int getfilename(char *prompt, char *buf, int nbuf)
 			break;
 
 		case 0x09: /* TAB, complete file name */
-			didtry = 1;
-
 			/* scan backwards for a wild card and set */
 			iswild=0;
 			while (cpos > 0) {
@@ -76,24 +74,16 @@ int getfilename(char *prompt, char *buf, int nbuf)
 				nskip = 0;
 			}
 
-			/* skip to start of next filename in the list */
-			c = ' ';
-			for (n = nskip; n > 0; n--)
-				while ((c = getc(fp)) != EOF && c != ' ')
-					;
-			nskip++;
-
-			/* at end of list */
-			if (c != ' ')
-				nskip = 0;
-
 			/* copy next filename into buf */
-			while ((c = getc(fp)) != EOF && c != '\n' && c != ' ' && c != '*')
-				if (cpos < nbuf - 1)
+			while ((c = getc(fp)) != EOF && c != '\n' && c != ' ')
+				if (cpos < nbuf - 1 && c != '*')
 					buf[cpos++] = c;
 
 			buf[cpos] = '\0';
-			rewind(fp);
+			if (c != ' ')
+				rewind(fp);
+
+			didtry = 1;
 			break;
 
 		default:

--- a/complete.c
+++ b/complete.c
@@ -6,7 +6,7 @@
 int getfilename(char *prompt, char *buf, int nbuf)
 {
 	int cpos = 0;	/* current character position in string */
-	int c, ocpos, n, nskip = 0, didtry = 0, iswild = 0, result = 0;
+	int c, n, nskip = 0, didtry = 0, iswild = 0, result = 0;
 
 	char sys_command[255];
 	char *output_file = NULL;
@@ -47,7 +47,6 @@ int getfilename(char *prompt, char *buf, int nbuf)
 
 		case 0x09: /* TAB, complete file name */
 			didtry = 1;
-			ocpos = cpos;
 
 			/* scan backwards for a wild card and set */
 			iswild=0;
@@ -60,7 +59,6 @@ int getfilename(char *prompt, char *buf, int nbuf)
 
 			/* first time retrieval */
 			if (nskip < 0) {
-				buf[ocpos] = 0;
 				if (fp != NULL)
 					fclose(fp);
 				strcpy(sys_command, "echo ");

--- a/complete.c
+++ b/complete.c
@@ -7,20 +7,18 @@ int getfilename(char *prompt, char *buf, int nbuf)
 {
 	static char temp_file[] = TEMPFILE;
 	int cpos = 0;	/* current character position in string */
-	int c, fd, nskip = 0, didtry = 0, iswild = 0;
+	int k = 0, c, fd, didtry, iswild = 0;
 
 	char sys_command[255];
 	FILE *fp = NULL;
 	buf[0] ='\0';
 
 	for (;;) {
-		if (!didtry)
-			nskip = -1;
-		didtry = 0;
+		didtry = (k == 0x09);	/* Was last command tab-completion? */
 		display_prompt_and_response(prompt, buf);
-		c = getch(); /* get a character from the user */
+		k = getch(); /* get a character from the user */
 
-		switch(c) {
+		switch(k) {
 		case 0x0a: /* cr, lf */
 		case 0x0d:
 			buf[cpos] = 0;
@@ -55,7 +53,7 @@ int getfilename(char *prompt, char *buf, int nbuf)
 			}
 
 			/* first time retrieval */
-			if (nskip < 0) {
+			if (! didtry) {
 				if (fp != NULL)
 					fclose(fp);
 				strcpy(temp_file, TEMPFILE);
@@ -71,7 +69,6 @@ int getfilename(char *prompt, char *buf, int nbuf)
 				(void) ! system(sys_command); /* stop compiler unused result warning */
 				fp = fdopen(fd, "r");
 				unlink(temp_file);
-				nskip = 0;
 			}
 
 			/* copy next filename into buf */
@@ -88,7 +85,7 @@ int getfilename(char *prompt, char *buf, int nbuf)
 
 		default:
 			if (cpos < nbuf - 1) {
-				  buf[cpos++] = c;
+				  buf[cpos++] = k;
 				  buf[cpos] = '\0';
 			}
 			break;

--- a/complete.c
+++ b/complete.c
@@ -6,7 +6,7 @@
 int getfilename(char *prompt, char *buf, int nbuf)
 {
 	int cpos = 0;	/* current character position in string */
-	int c, n, nskip = 0, didtry = 0, iswild = 0, result = 0;
+	int c, n, nskip = 0, didtry = 0, iswild = 0;
 
 	char sys_command[255];
 	char *output_file = NULL;
@@ -69,8 +69,7 @@ int getfilename(char *prompt, char *buf, int nbuf)
 				output_file = get_temp_file();
 				strcat(sys_command, output_file);
 				strcat(sys_command, " 2>&1");
-				result = system(sys_command);
-				result++; /* stop compiler warning about not used */
+				(void) ! system(sys_command); /* stop compiler unused result warning */
 				fp = fopen(output_file, "r");
 				nskip = 0;
 			}

--- a/complete.c
+++ b/complete.c
@@ -19,17 +19,12 @@ int getfilename(char *prompt, char *buf, int nbuf)
 		k = getch(); /* get a character from the user */
 
 		switch(k) {
+		case 0x07: /* ctrl-g, abort */
 		case 0x0a: /* cr, lf */
 		case 0x0d:
-			buf[cpos] = 0;
 			if (fp != NULL)
 				fclose(fp);
-			return (cpos > 0 ? TRUE : FALSE);
-
-		case 0x07: /* ctrl-g, abort */
-			if (fp != NULL)
-				fclose(fp);
-			return FALSE;
+			return (k != 0x07 && cpos > 0);
 
 		case 0x7f: /* del, erase */
 		case 0x08: /* backspace */

--- a/header.h
+++ b/header.h
@@ -178,7 +178,6 @@ extern point_t search_forward(buffer_t *, point_t, char *);
 extern point_t search_backwards(buffer_t *, point_t, char *);
 extern void update_search_prompt(char *, char *);
 extern void display_search_result(point_t, int, char *, char *);
-extern char* get_temp_file(void);
 extern buffer_t* find_buffer(char *, int);
 extern void buffer_init(buffer_t *);
 extern int delete_buffer(buffer_t *);


### PR DESCRIPTION
My previous PR for issue #7 unfortunately increased the code size by 6 lines.  This prompted me to review the implementation of filename completion.  This PR reworks how it operates, avoiding the rewind between each tab, and reduces the code by 26 lines.  However, it does slightly change the behaviour (no empty result before cycling from the start again) - I prefer the changed behaviour, but you may disagree.
