### PR TITLE
Load all files on command line and optionally jump to specified line

### DIFF
--- a/header.h
+++ b/header.h
@@ -206,3 +206,4 @@ extern void set_parse_state(buffer_t *, point_t);
 extern void set_parse_state2(buffer_t *, point_t);
 extern int parse_text(buffer_t *, point_t);
 extern void resize_terminal();
+extern void arguments(int argc, char **argv);


### PR DESCRIPTION
Issuing `./atto +10 README.md main.c -- +5` in the source directory will:
- open README.md with the cursor set to line 10
- open main.c
- try to open the non existing file `+5`

This patch adds 19 Wheeler's SLOC and 24 netto lines to atto.
`wc -l *.[ch]` gives 1994.