### PR TITLE
Add C-z command to suspend the editor to the calling shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Atto is based on the public domain code of Anthony Howe's editor (commonly known
     C-W   Kill Region (Cut)
     C-X   CTRL-X command prefix
     C-Y   Yank (Paste)
+    C-Y   Suspend the Atto process (Run 'fg' at the shell to resume it)
 
     M-<   Start of file
     M->   End of file

--- a/command.c
+++ b/command.c
@@ -354,3 +354,14 @@ void showpos()
 			curbp->b_point, ((curbp->b_ebuf - curbp->b_buf) - (curbp->b_egap - curbp->b_gap)));
 	}
 }
+
+void suspend()
+{
+	noraw();
+	endwin();
+	kill(0, SIGSTOP);
+	raw();
+	noecho();
+	idlok(stdscr, TRUE);
+
+}

--- a/command.c
+++ b/command.c
@@ -355,13 +355,4 @@ void showpos()
 	}
 }
 
-void suspend()
-{
-	noraw();
-	endwin();
-	kill(0, SIGSTOP);
-	raw();
-	noecho();
-	idlok(stdscr, TRUE);
-
-}
+void suspend() { raise(SIGTSTP); }

--- a/header.h
+++ b/header.h
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <wchar.h>
+#include <signal.h>
 int mkstemp(char *);
 
 #define VERSION	 "Atto 1.22, Public Domain, Dec 2020, by Hugh Barney,  No warranty."
@@ -155,6 +156,7 @@ extern void left(void);
 extern void lnbegin(void);
 extern void lnend(void);
 extern void paste(void);
+extern void suspend(void);
 extern void pgdown(void);
 extern void pgup(void);
 extern void quit(void);

--- a/key.c
+++ b/key.c
@@ -19,6 +19,7 @@ keymap_t keymap[] = {
 	{"C-v forward-page         ", "\x16", pgdown },
 	{"C-w kill-region          ", "\x17", cut},
 	{"C-y yank                 ", "\x19", paste},
+	{"C-z suspend              ", "\x1A", suspend},
 	{"C-space set-mark         ", "\x00", iblock },  /* ctrl-space */
 	{"C-x 1 delete-other-window", "\x18\x31", delete_other_windows },
 	{"C-x 2 split-window       ", "\x18\x32", split_window },


### PR DESCRIPTION
This is a useful feature, especially when working on a remote machine.

I am absolutely unsure about the
`noraw(); endwin();` and the `raw(); noecho(); idlok(stdscr, TRUE);` sequences, they are just guesses taken from `main.c`, but they seem to do their job.

Wheelers SLOC: 1622 (vs. 1610)
Line count: 1984 (vs. 1970)